### PR TITLE
Remove deprecated template_file data object

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ No requirements.
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.61.0 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
 
 ## Modules
 
@@ -64,7 +63,6 @@ No modules.
 | [aws_security_group_rule.orchestrator_agent_egress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.orchestrator_agent_ingress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [template_file.orchestrator_agent_container_definitions](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -10,20 +10,4 @@ resource "aws_cloudwatch_log_group" "orchestrator_agent" {
   tags = merge(var.tags, var.default_tags)
 }
 
-data "template_file" "orchestrator_agent_container_definitions" {
-  template = file("${path.module}/container-definitions/orchestrator-agent.json")
-
-  vars = {
-    agent_image = var.agent_image
-    access_key = var.access_key
-    collector_host = var.collector_host
-    collector_port = var.collector_port
-    agent_tags = var.agent_tags
-    check_certificate = var.check_collector_certificate
-    orchestrator_port = var.orchestrator_port
-    awslogs_region = data.aws_region.current_region.name
-    awslogs_group = "${var.name}-logs"
-  }
-}
-
 data "aws_region" "current_region" {}

--- a/task.tf
+++ b/task.tf
@@ -6,7 +6,18 @@ resource "aws_ecs_task_definition" "orchestrator_agent" {
   requires_compatibilities = ["FARGATE"]
   cpu = "2048"
   memory = "8192"
-  container_definitions = data.template_file.orchestrator_agent_container_definitions.rendered
+
+  container_definitions = templatefile("${path.module}/container-definitions/orchestrator-agent.json", {
+    agent_image = var.agent_image
+    access_key = var.access_key
+    collector_host = var.collector_host
+    collector_port = var.collector_port
+    agent_tags = var.agent_tags
+    check_certificate = var.check_collector_certificate
+    orchestrator_port = var.orchestrator_port
+    awslogs_region = data.aws_region.current_region.name
+    awslogs_group = "${var.name}-logs"
+  })
 
   tags = merge(var.tags, var.default_tags)
 }


### PR DESCRIPTION
The template provider has been deprecated and archived, as a result this module does not work on M1 architecture as there is no build available.

This PR removes the dependency on the template_file provider and uses the templatefile function.