### PR TITLE
feat: enable fetching of secretsmanager-backed access key

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,54 +38,54 @@ No requirements.
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.61.0 |
+| Name                                              | Version |
+|---------------------------------------------------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.61.0  |
 
 ## Modules
 
 No modules.
 
-## Resources
+## Resources and Data Sources
 
-| Name | Type |
-|------|------|
-| [aws_cloudwatch_log_group.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
-| [aws_ecs_cluster.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
-| [aws_ecs_service.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
-| [aws_ecs_task_definition.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
-| [aws_iam_role.orchestrator_agent_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.orchestrator_agent_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_lb.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
-| [aws_lb_listener.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
-| [aws_security_group.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.orchestrator_agent_egress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.orchestrator_agent_ingress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| Name                                                                                                                                                                | Type        |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| [aws_cloudwatch_log_group.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group)                     | resource    |
+| [aws_ecs_cluster.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster)                                       | resource    |
+| [aws_ecs_service.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service)                                       | resource    |
+| [aws_ecs_task_definition.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition)                       | resource    |
+| [aws_iam_role.orchestrator_agent_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                              | resource    |
+| [aws_iam_role.orchestrator_agent_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                   | resource    |
+| [aws_lb.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb)                                                         | resource    |
+| [aws_lb_listener.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener)                                       | resource    |
+| [aws_lb_target_group.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group)                               | resource    |
+| [aws_security_group.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group)                                 | resource    |
+| [aws_security_group_rule.orchestrator_agent_egress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule)           | resource    |
+| [aws_security_group_rule.orchestrator_agent_ingress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule)          | resource    |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region)                                                  | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_access_key"></a> [access\_key](#input\_access\_key) | Sysdig access key | `string` | n/a | yes |
-| <a name="input_agent_image"></a> [agent\_image](#input\_agent\_image) | Orchestrator agent image | `string` | `"quay.io/sysdig/orchestrator-agent:latest"` | no |
-| <a name="input_agent_tags"></a> [agent\_tags](#input\_agent\_tags) | Comma separated list of tags for this agent | `string` | `""` | no |
-| <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Provisions a public IP for the service. Required when using an Internet Gateway for egress. | `bool` | `false` | no |
-| <a name="input_check_collector_certificate"></a> [check\_collector\_certificate](#input\_check\_collector\_certificate) | Whether to check the collector certificate when connecting. Mainly for development. | `string` | `"true"` | no |
-| <a name="input_collector_host"></a> [collector\_host](#input\_collector\_host) | Sysdig collector host | `string` | `"collector.sysdigcloud.com"` | no |
-| <a name="input_collector_port"></a> [collector\_port](#input\_collector\_port) | Sysdig collector port | `string` | `"6443"` | no |
-| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default tags for all Sysdig Fargate Orchestrator resources | `map(string)` | <pre>{<br>  "Application": "sysdig",<br>  "Module": "fargate-orchestrator-agent"<br>}</pre> | no |
-| <a name="input_name"></a> [name](#input\_name) | Identifier for module resources | `string` | `"sysdig-fargate-orchestrator"` | no |
-| <a name="input_orchestrator_port"></a> [orchestrator\_port](#input\_orchestrator\_port) | Port for the workload agent to connect | `number` | `6667` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of subnets that can access the internet and are reachable by instrumented services. The subnets must be in at least 2 different AZs. | `list(string)` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Extra tags for all Sysdig Fargate Orchestrator resources | `map(string)` | `{}` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC where the orchestrator should be installed | `string` | n/a | yes |
+| Name                                                                                                                                              | Description                                                                                                                                                                                       | Type           | Default                                                                                     | Required |
+|---------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|---------------------------------------------------------------------------------------------|:--------:|
+| <a name="input_access_key"></a> [access\_key](#input\_access\_key)                                                                                | Sysdig Access Key as either clear text or SecretsManager-backed secret reference (expected pattern: `arn:aws:secretsmanager:region:accountId:secret:secretName[:jsonKey:versionStage:versionId]`) | `string`       | n/a                                                                                         |   yes    |
+| <a name="input_agent_image"></a> [agent\_image](#input\_agent\_image)                                                                             | Orchestrator agent image                                                                                                                                                                          | `string`       | `"quay.io/sysdig/orchestrator-agent:latest"`                                                |    no    |
+| <a name="input_agent_tags"></a> [agent\_tags](#input\_agent\_tags)                                                                                | Comma separated list of tags for this agent                                                                                                                                                       | `string`       | `""`                                                                                        |    no    |
+| <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip)                                                            | Provisions a public IP for the service. Required when using an Internet Gateway for egress.                                                                                                       | `bool`         | `false`                                                                                     |    no    |
+| <a name="input_check_collector_certificate"></a> [check\_collector\_certificate](#input\_check\_collector\_certificate)                           | Whether to check the collector certificate when connecting. Mainly for development.                                                                                                               | `string`       | `"true"`                                                                                    |    no    |
+| <a name="input_collector_host"></a> [collector\_host](#input\_collector\_host)                                                                    | Sysdig collector host                                                                                                                                                                             | `string`       | `"collector.sysdigcloud.com"`                                                               |    no    |
+| <a name="input_collector_port"></a> [collector\_port](#input\_collector\_port)                                                                    | Sysdig collector port                                                                                                                                                                             | `string`       | `"6443"`                                                                                    |    no    |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags)                                                                          | Default tags for all Sysdig Fargate Orchestrator resources                                                                                                                                        | `map(string)`  | <pre>{<br>  "Application": "sysdig",<br>  "Module": "fargate-orchestrator-agent"<br>}</pre> |    no    |
+| <a name="input_name"></a> [name](#input\_name)                                                                                                    | Identifier for module resources                                                                                                                                                                   | `string`       | `"sysdig-fargate-orchestrator"`                                                             |    no    |
+| <a name="input_orchestrator_port"></a> [orchestrator\_port](#input\_orchestrator\_port)                                                           | Port for the workload agent to connect                                                                                                                                                            | `number`       | `6667`                                                                                      |    no    |
+| <a name="input_subnets"></a> [subnets](#input\_subnets)                                                                                           | A list of subnets that can access the internet and are reachable by instrumented services. The subnets must be in at least 2 different AZs.                                                       | `list(string)` | n/a                                                                                         |   yes    |
+| <a name="input_tags"></a> [tags](#input\_tags)                                                                                                    | Extra tags for all Sysdig Fargate Orchestrator resources                                                                                                                                          | `map(string)`  | `{}`                                                                                        |    no    |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id)                                                                                            | ID of the VPC where the orchestrator should be installed                                                                                                                                          | `string`       | n/a                                                                                         |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
+| Name                                                                                      | Description                                      |
+|-------------------------------------------------------------------------------------------|--------------------------------------------------|
 | <a name="output_orchestrator_host"></a> [orchestrator\_host](#output\_orchestrator\_host) | The DNS name of the orchestrator's load balancer |
-| <a name="output_orchestrator_port"></a> [orchestrator\_port](#output\_orchestrator\_port) | The configured port on the orchestrator |
+| <a name="output_orchestrator_port"></a> [orchestrator\_port](#output\_orchestrator\_port) | The configured port on the orchestrator          |
 <!-- END_TF_DOCS -->

--- a/container-definitions/orchestrator-agent.json
+++ b/container-definitions/orchestrator-agent.json
@@ -9,32 +9,8 @@
                                 "containerPort": ${orchestrator_port}
                         }
                 ],
-                "environment": [
-                        {
-                                "name": "ACCESS_KEY",
-                                "value": "${access_key}"
-                        },
-                        {
-                                "name": "CHECK_CERTIFICATE",
-                                "value": "${check_certificate}"
-                        },
-                        {
-                                "name": "COLLECTOR",
-                                "value": "${collector_host}"
-                        },
-                        {
-                                "name": "COLLECTOR_PORT",
-                                "value": "${collector_port}"
-                        },
-                        {
-                                "name": "TAGS",
-                                "value": "${agent_tags}"
-                        },
-                        {
-                                "name": "ADDITIONAL_CONF",
-                                "value": "agentino_port: ${orchestrator_port}"
-                        }
-                ],
+                "secrets": ${jsonencode(secrets)},
+                "environment": ${jsonencode(environment)},
                 "logConfiguration": {
                         "logDriver": "awslogs",
                         "options": {

--- a/roles.tf
+++ b/roles.tf
@@ -1,7 +1,35 @@
+locals {
+  secret_reference = local.do_fetch_secret ? split(":", var.access_key) : []
+}
+
 resource "aws_iam_role" "orchestrator_agent_execution_role" {
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
+
+  dynamic "inline_policy" {
+    for_each = local.do_fetch_secret ? ["SecretsManagerAccessKey"] : []
+    content {
+      name = "root"
+      policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Action = [
+              "secretsmanager:GetSecretValue",
+            ]
+            Effect = "Allow"
+            Resource = [format("arn:aws:secretsmanager:%s:%s:secret:%s",
+              element(local.secret_reference, 3),
+              element(local.secret_reference, 4),
+              element(local.secret_reference, 6)
+              )
+            ]
+          },
+        ]
+      })
+    }
+  }
 
   tags = merge(var.tags, var.default_tags)
 }

--- a/task.tf
+++ b/task.tf
@@ -1,3 +1,47 @@
+locals {
+  access_key_secretsmanager_reference = startswith(var.access_key, "arn:aws:secretsmanager:") ? [split(":", var.access_key)] : []
+}
+
+locals {
+  secrets = local.do_fetch_secret ? [
+    {
+      name      = "ACCESS_KEY",
+      valueFrom = var.access_key
+    }
+  ] : []
+
+  environment = concat(
+    local.do_fetch_secret ? [] : [
+      {
+        name  = "ACCESS_KEY",
+        value = var.access_key
+      }
+    ],
+    [
+      {
+        name  = "CHECK_CERTIFICATE",
+        value = var.check_collector_certificate
+      },
+      {
+        name  = "COLLECTOR",
+        value = var.collector_host
+      },
+      {
+        name  = "COLLECTOR_PORT",
+        value = var.collector_port
+      },
+      {
+        name  = "TAGS",
+        value = var.agent_tags
+      },
+      {
+        name  = "ADDITIONAL_CONF",
+        value = format("agentino_port: %s", tostring(var.orchestrator_port))
+      }
+    ]
+  )
+}
+
 resource "aws_ecs_task_definition" "orchestrator_agent" {
   family                   = "${var.name}-orchestrator-agent"
   task_role_arn            = aws_iam_role.orchestrator_agent_task_role.arn
@@ -9,14 +53,11 @@ resource "aws_ecs_task_definition" "orchestrator_agent" {
 
   container_definitions = templatefile("${path.module}/container-definitions/orchestrator-agent.json", {
     agent_image       = var.agent_image
-    access_key        = var.access_key
-    collector_host    = var.collector_host
-    collector_port    = var.collector_port
-    agent_tags        = var.agent_tags
-    check_certificate = var.check_collector_certificate
-    orchestrator_port = var.orchestrator_port
     awslogs_region    = data.aws_region.current_region.name
     awslogs_group     = "${var.name}-logs"
+    orchestrator_port = var.orchestrator_port
+    secrets           = local.secrets
+    environment       = local.environment
   })
 
   tags = merge(var.tags, var.default_tags)

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,21 @@ variable "vpc_id" {
 }
 
 variable "access_key" {
-  description = "Sysdig access key"
+  description = "Sysdig Access Key, as either clear text or SecretsManager-backed secret reference"
   type        = string
+  sensitive   = true
+  validation {
+    # Expected pattern "arn:aws:secretsmanager:region:accountId:secret:secretName[:jsonKey:versionStage:versionId]"
+    condition = (startswith(var.access_key, "arn:aws:secretsmanager:")
+      ? (can(regex("arn:aws:secretsmanager:[^:]+:[^:]+:secret:[^:]+(:[^:]*:[^:]*:[^:]*)?", var.access_key)) ? true : false)
+      : true
+    )
+    error_message = "The string did not match the expected pattern 'arn:aws:secretsmanager:region:accountId:secret:secretName[:jsonKey:versionStage:versionId]'"
+  }
+}
+
+locals {
+  do_fetch_secret = startswith(var.access_key, "arn:aws:secretsmanager:") ? true : false
 }
 
 variable "subnets" {


### PR DESCRIPTION
# Description
This PR enables the fetching of SecretsManager-backed access keys.

The variable `access_key` can now handle secret references as described in [aws.doc.specifying-sensitive-data-secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html#secrets-application-retrieval), other than clear text keys.

Secret references have the following pattern:
```
arn:aws:secretsmanager:region:aws_account_id:secret:secret-name:json-key:version-stage:version-id
```
and contains two "pieces":
 - `arn:aws:secretsmanager:region:aws_account_id:secret:secret-name` which is the mandatory SecretARN;
 - `:json-key:version-stage:version-id` which is the optional part specifying the JSON Key, the version stage, and the version id of the secret.

Note that this PR:
 -  ensures backward compatibility (users can keep using clear text keys)
 -  marks `access_key` as sensitive to prevent secrets from being logged.


### Examples
For example, users can fetch the access key stored in the SecretsManager-backed secret `guess-my-secrets-QWerTY` as follows.

#### Referencing a plaintext secret
```shell
sysdig_orchestrator_agent.access_key = "arn:aws:secretsmanager:us-east-1:012345678987:secret:guess-my-secrets-QWerTY"
```
Since this references a plaintext secret, the optional part can be omitted.

#### Referencing a specific key
```shell
sysdig_orchestrator_agent.access_key = "arn:aws:secretsmanager:us-east-1:012345678987:secret:guess-my-secrets-QWerTY:MyJSONKey::"
```
Note that the trailing columns have to be defined even if we don’t want to fetch any particular label/version.

#### Referencing a specific key and version staging label
```shell
sysdig_orchestrator_agent.access_key = "arn:aws:secretsmanager:us-east-1:012345678987:secret:guess-my-secrets-QWerTY:MyJSONKey:AWSPREVIOUS:"
```
