### PR TITLE
refactor: remove redundant task role

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ No modules.
 | [aws_ecs_service.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service)                                       | resource    |
 | [aws_ecs_task_definition.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition)                       | resource    |
 | [aws_iam_role.orchestrator_agent_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                              | resource    |
-| [aws_iam_role.orchestrator_agent_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                   | resource    |
 | [aws_lb.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb)                                                         | resource    |
 | [aws_lb_listener.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener)                                       | resource    |
 | [aws_lb_target_group.orchestrator_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group)                               | resource    |

--- a/roles.tf
+++ b/roles.tf
@@ -34,17 +34,6 @@ resource "aws_iam_role" "orchestrator_agent_execution_role" {
   tags = merge(var.tags, var.default_tags)
 }
 
-resource "aws_iam_role" "orchestrator_agent_task_role" {
-  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
-
-  inline_policy {
-    name   = "root"
-    policy = data.aws_iam_policy_document.task_policy.json
-  }
-
-  tags = merge(var.tags, var.default_tags)
-}
-
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -53,21 +42,5 @@ data "aws_iam_policy_document" "assume_role_policy" {
       type        = "Service"
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
-  }
-}
-
-data "aws_iam_policy_document" "task_policy" {
-  statement {
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    resources = ["*"]
   }
 }

--- a/task.tf
+++ b/task.tf
@@ -56,7 +56,6 @@ locals {
 
 resource "aws_ecs_task_definition" "orchestrator_agent" {
   family                   = "${var.name}-orchestrator-agent"
-  task_role_arn            = aws_iam_role.orchestrator_agent_task_role.arn
   execution_role_arn       = aws_iam_role.orchestrator_agent_execution_role.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]


### PR DESCRIPTION
# Description
This PR removes the redundant `TaskRole` in the `TaskDefinition` of the orchestrator.