### PR TITLE
fix: remove unuseful access key from workload-agent data source

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -29,8 +29,6 @@ data "sysdig_fargate_workload_agent" "instrumented" {
     }
   ])
 
-  sysdig_access_key = ""
-
   workload_agent_image = var.sysdig_workload_agent_image
 
   orchestrator_host = module.sysdig_orchestrator_agent.orchestrator_host


### PR DESCRIPTION
# Description
The access key is no longer required in the workload-agent data source.

# Related PR
https://github.com/sysdiglabs/terraform-provider-sysdig/pull/299