### PR TITLE
chore(github) Add code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners
+    @francesco-racciatti @gnosek @pgcrooks-sysdig


### PR DESCRIPTION
Adding a codeowners file, containing the Sysdig Serverless Agent team