### PR TITLE
chore(docs): Use the correct warning header format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-> [!WARNING]
-> The _Sysdig Orchestrator Agent_ will be deprecated in **June 2025** in favour of _Workload Agents_ connecting directly to Sysdig endpoints.
+!> The _Sysdig Orchestrator Agent_ will be deprecated in **June 2025** in favour of _Workload Agents_ connecting directly to Sysdig endpoints.
 
 # Sysdig Orchestrator Agent for ECS Fargate
 


### PR DESCRIPTION
Last time I used the wrong format for terraform registry.

![Screenshot 2025-04-02 at 14 08 46](https://github.com/user-attachments/assets/a6f51f1d-df60-499c-a5c1-523cb44f0bd5)

Ref: https://developer.hashicorp.com/terraform/registry/providers/docs#callouts